### PR TITLE
Resolve module name from imports if possible

### DIFF
--- a/lib/GhcideSteal.hs
+++ b/lib/GhcideSteal.hs
@@ -194,10 +194,10 @@ defRowToLocation wsroot imports (row :. info) = do
   let start = Position <$> (intToUInt $ defSLine row - 1) <*> (intToUInt $ defSCol row - 1)
       end = Position <$> (intToUInt $ defELine row - 1) <*> (intToUInt $ defECol row - 1)
       range = Range <$> start <*> end
-  file <- case modInfoSrcFile info of
-    Just src -> pure $ filePathToUri $ wsroot </> src
-    Nothing -> MaybeT $ pure $ M.lookup (modInfoName info) imports
-  Location file <$> (MaybeT . pure $ range)
+      file = case modInfoSrcFile info of
+                Just src -> Just $ filePathToUri $ wsroot </> src
+                Nothing -> M.lookup (modInfoName info) imports
+  MaybeT $ pure $ Location <$> file <*> range
 
 dropEnd1 :: [a] -> [a]
 dropEnd1 [] = []


### PR DESCRIPTION
sometimes `modinfoSrcFile` cannot resolve the file name since of a module despite the file being indexed by hiedb causing jump to definition to fail even though we have the necessary information (I believe this can happen if it's a seperate build target eg test vs library). We can use `modInfoName` to resolve the module and which fixes the jump to definition